### PR TITLE
setuptools-git-version not needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 setup(
     name='INGRID',
     version_format='{tag}',
-    setup_requires=['setuptools-git-version'],
+    setup_requires=['setuptools'],
     description='Tokamak edge plasma grid generator',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
If following instructions here https://ingrid.readthedocs.io/en/latest/installation.html
then only setuptools is available, not setuptools-git-version.