### PR TITLE
UDN Topology XPT "tilt" modifier bugfix

### DIFF
--- a/INGRID/topologies/udn.py
+++ b/INGRID/topologies/udn.py
@@ -304,14 +304,14 @@ class UDN(TopologyUtils):
 
         if self.settings['grid_settings']['patch_generation']['use_xpt2_W']:
             tilt = self.settings['grid_settings']['patch_generation']['xpt2_W_tilt']
-            E3_E = self.LineTracer.draw_line(xpt2['W'], {'psi_horizontal': (psi_2, tilt)}, option='z_const', direction='cw', show_plot=visual, text=verbose).reverse_copy()
+            E3_E = self.LineTracer.draw_line(xpt2['W'], {'psi_horizontal': (psi_2, tilt)}, option='z_const', direction='ccw', show_plot=visual, text=verbose).reverse_copy()
         else:
             E3_E = self.LineTracer.draw_line(xpt2['W'], {'psi': psi_2}, option='rho', direction='ccw', show_plot=visual, text=verbose).reverse_copy()
         F3_W = E3_E.reverse_copy()
 
         if self.settings['grid_settings']['patch_generation']['use_xpt2_E']:
             tilt = self.settings['grid_settings']['patch_generation']['xpt2_E_tilt']
-            D3_W = self.LineTracer.draw_line(xpt2['E'], {'psi_horizontal': (psi_1, tilt)}, option='z_const', direction='ccw', show_plot=visual, text=verbose)
+            D3_W = self.LineTracer.draw_line(xpt2['E'], {'psi_horizontal': (psi_1, tilt)}, option='z_const', direction='cw', show_plot=visual, text=verbose)
         else:
             D3_W = self.LineTracer.draw_line(xpt2['E'], {'psi': psi_1}, option='rho', direction='ccw', show_plot=visual, text=verbose)
         C3_E = D3_W.reverse_copy()
@@ -341,7 +341,7 @@ class UDN(TopologyUtils):
         G2_E = H2_W.reverse_copy()
 
         if self.settings['grid_settings']['patch_generation']['use_xpt1_W']:
-            tilt = -self.settings['grid_settings']['patch_generation']['xpt1_W_tilt']
+            tilt = self.settings['grid_settings']['patch_generation']['xpt1_W_tilt']
             B3_W = self.LineTracer.draw_line(B2_W.p[-1], {'line': (midline_1__WestPlate1, tilt)}, option='z_const', direction='ccw', show_plot=visual, text=verbose)
         else:
             B3_W = self.LineTracer.draw_line(B2_W.p[-1], {'line': midline_1__WestPlate1},

--- a/example_files/UDN/DIIID_UDN.yml
+++ b/example_files/UDN/DIIID_UDN.yml
@@ -11,7 +11,7 @@ DEBUG:
 eqdsk: ../data/UDN/DIII-D/neqdsk
 grid_settings:
   grid_generation:
-    skewness_correction:
+    distortion_correction:
       all:
         active: false
         resolution: 1000
@@ -25,19 +25,18 @@ grid_settings:
   nlevs: 30
   num_xpt: 2
   patch_generation:
-    pf_split_point_ratio: 0.5
+    xpt2_E_tilt: -2.0
+    xpt2_W_tilt: -3.2
     xpt1_E_tilt: 0.0
-    xpt1_W_tilt: 0.65
+    xpt1_W_tilt: -0.9
     rmagx_shift: 0.0
-    xpt2_E_tilt: 0.0
-    xpt2_W_tilt: 0.0
     strike_pt_loc: limiter
     magx_tilt_1: 0.0
     magx_tilt_2: 0.0
-    use_xpt1_E: false
-    use_xpt1_W: false
-    use_xpt2_E: false
-    use_xpt2_W: false
+    use_xpt1_E: False
+    use_xpt1_W: False
+    use_xpt2_E: False
+    use_xpt2_W: False
     zmagx_shift: 0.0
   psi_1: 1.127
   psi_2: 1.131758078227


### PR DESCRIPTION
This PR resolves a UDN topology issue when applying the tilt operator for the "E" and "W" directions to XPT2.

Additionally, the 'example_files/UDN' case has been updated to illustrate a configuration utilizing tilt operators for both the primary and secondary xpts.