### PR TITLE
Fix: Enforce numpy >= 1.20 to ensure numpy.typing module is available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         'm2r2',
         'scipy >= 1.3.1',
-        'numpy',
+        'numpy >= 1.20.0',
         'pyyaml',
         'matplotlib',
         'tk',


### PR DESCRIPTION
## Description of changes
The freeqdsk module utilizes the `numpy.typing` module introduced in `numpy 1.20` yet does not enforce said version. This edit ensures we utilize a modern build of numpy.

## How was this tested?
CI

## Relevant issues
N/A

## Checklist
[//]: # (A list of items to complete)
[//]: # (Place a strikethrough for any irrelevant boxes with ~~ before and after the item)
- ~~[ ] I have added/updated tests relevant to this PR.~~
- ~~[ ] I have updated any baselines required for the test suite.~~
- [x] I have run the test suite locally to ensure my changes work as intended.
