### PR TITLE
Support parsing 2-xpoint gridue header

### DIFF
--- a/INGRID/ingrid.py
+++ b/INGRID/ingrid.py
@@ -1489,9 +1489,25 @@ class Ingrid(IngridUtils):
         try:
             f = open(fname, mode='r')
             Values = [int(x) for x in next(f).split()]
-            HeaderItems = ['nxm', 'nym', 'ixpt1', 'ixpt2', 'iyseptrx1']
-            gridue_settings = dict(zip(HeaderItems, Values))
-            next(f)
+            
+            # Very crude method of checking what format the gridue is in
+            if len(Values) > 2:
+                HeaderItems = ['nxm', 'nym', 'ixpt1', 'ixpt2', 'iyseptrx1']
+                gridue_settings = dict(zip(HeaderItems, Values))
+                next(f)
+            else:
+                gridue_settings = {}
+                header_rows = [
+                    ['nxm', 'nym'],
+                    ['iyseparatrix1', 'iyseparatrix2'],
+                    ['ix_plate1', 'ix_cut1', '_FILLER_', 'ix_cut2', 'ix_plate2'],
+                    ['iyseparatrix3', 'iyseparatrix4'],
+                    ['ix_plate3', 'ix_cut3', '_FILLER_', 'ix_cut4', 'ix_plate4']
+                ]
+                for row in header_rows:
+                    gridue_settings = {**gridue_settings, **dict(zip(row, Values))}
+                    Values = [int(x) for x in next(f).split()]
+
             BodyItems = ['rm', 'zm', 'psi', 'br', 'bz', 'bpol', 'bphi', 'b']
             Str = {i: [] for i in BodyItems}
             k = iter(Str.keys())


### PR DESCRIPTION
## Description of changes
[//]: Parse `gridue` with double null headers properly in `ImportGridue`. This allows `gridue` for UDN and SF cases to be plot.

## How was this tested?
[//]: Following the procedure and using the script in #31. The UDN and SF75 mesh is now plot correctly
<img width="586" alt="image" src="https://github.com/user-attachments/assets/ba6af0e3-36c6-45de-a317-74004d596843" />
<img width="593" alt="image" src="https://github.com/user-attachments/assets/d5a914c3-3a82-4e12-97be-97c4c71118b2" />



## Relevant issues
[//]: #31 

## Checklist
[//]: # (A list of items to complete)
[//]: # (Place a strikethrough for any irrelevant boxes with ~~ before and after the item)
- ~~[ ] I have added/updated tests relevant to this PR.~~
- ~~[ ] I have updated any baselines required for the test suite.~~
- [ ] I have run the test suite locally to ensure my changes work as intended.
