### PR TITLE
Remove python 3.8 support

### DIFF
--- a/.github/workflows/ingrid_ci.yml
+++ b/.github/workflows/ingrid_ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
As discussed, removing support for python 3.8 and so removing it from the CI pipeline.
